### PR TITLE
Revert-max_token_cap

### DIFF
--- a/database/aoai-proxy.sql
+++ b/database/aoai-proxy.sql
@@ -45,7 +45,7 @@ ALTER TYPE aoai.model_type OWNER TO admin;
 -- Name: add_event(uuid, character varying, character varying, timestamp without time zone, timestamp without time zone, character varying, character varying, character varying, character varying, integer, boolean, integer, boolean); Type: FUNCTION; Schema: aoai; Owner: admin
 --
 
-CREATE FUNCTION aoai.add_event(p_entra_id character varying, p_event_code character varying, p_event_markdown character varying, p_start_utc timestamp without time zone, p_end_utc timestamp without time zone, p_organizer_name character varying, p_organizer_email character varying, p_event_url character varying, p_event_url_text character varying, p_max_token_cap integer, p_single_code boolean, p_daily_request_cap integer, p_active boolean) RETURNS TABLE(event_id character varying, owner_id uuid, event_code character varying, event_markdown character varying, start_utc timestamp without time zone, end_utc timestamp without time zone, organizer_name character varying, organizer_email character varying, event_url character varying, event_url_text character varying, max_token_cap integer, single_code boolean, daily_request_cap integer, active boolean)
+CREATE FUNCTION aoai.add_event(p_entra_id character varying, p_event_code character varying, p_event_markdown character varying, p_start_utc timestamp without time zone, p_end_utc timestamp without time zone, p_organizer_name character varying, p_organizer_email character varying, p_event_url character varying, p_event_url_text character varying, p_max_token_cap integer, p_daily_request_cap integer, p_active boolean) RETURNS TABLE(event_id character varying, owner_id uuid, event_code character varying, event_markdown character varying, start_utc timestamp without time zone, end_utc timestamp without time zone, organizer_name character varying, organizer_email character varying, event_url character varying, event_url_text character varying, max_token_cap integer, daily_request_cap integer, active boolean)
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -80,7 +80,6 @@ BEGIN
         event_url,
         event_url_text,
         max_token_cap,
-        single_code,
         daily_request_cap,
         active
     )
@@ -96,7 +95,6 @@ BEGIN
 		p_event_url,
 		p_event_url_text,
 		p_max_token_cap,
-		p_single_code,
 		p_daily_request_cap,
 		p_active
 		);
@@ -113,14 +111,14 @@ BEGIN
     );
 
 	RETURN QUERY
-	SELECT e.event_id, e.owner_id, e.event_code, e.event_markdown, e.start_utc, e.end_utc, e.organizer_name, e.organizer_email, e.event_url, e.event_url_text, e.max_token_cap, e.single_code, e.daily_request_cap, e.active
+	SELECT e.event_id, e.owner_id, e.event_code, e.event_markdown, e.start_utc, e.end_utc, e.organizer_name, e.organizer_email, e.event_url, e.event_url_text, e.max_token_cap, e.daily_request_cap, e.active
 	FROM aoai.event as e WHERE e.event_id = v_final_hash;
 
 END;
 $$;
 
 
-ALTER FUNCTION aoai.add_event(p_entra_id character varying, p_event_code character varying, p_event_markdown character varying, p_start_utc timestamp without time zone, p_end_utc timestamp without time zone, p_organizer_name character varying, p_organizer_email character varying, p_event_url character varying, p_event_url_text character varying, p_max_token_cap integer, p_single_code boolean, p_daily_request_cap integer, p_active boolean) OWNER TO admin;
+ALTER FUNCTION aoai.add_event(p_entra_id character varying, p_event_code character varying, p_event_markdown character varying, p_start_utc timestamp without time zone, p_end_utc timestamp without time zone, p_organizer_name character varying, p_organizer_email character varying, p_event_url character varying, p_event_url_text character varying, p_max_token_cap integer, p_daily_request_cap integer, p_active boolean) OWNER TO admin;
 
 --
 -- Name: add_event_attendee(character varying, character varying); Type: FUNCTION; Schema: aoai; Owner: admin
@@ -290,7 +288,6 @@ CREATE TABLE aoai.event (
     event_url character varying(256) NOT NULL,
     event_url_text character varying(256) NOT NULL,
     max_token_cap integer NOT NULL,
-    single_code boolean NOT NULL,
     daily_request_cap integer NOT NULL,
     active boolean NOT NULL
 );

--- a/database/aoai-proxy.sql
+++ b/database/aoai-proxy.sql
@@ -45,7 +45,7 @@ ALTER TYPE aoai.model_type OWNER TO admin;
 -- Name: add_event(uuid, character varying, character varying, timestamp without time zone, timestamp without time zone, character varying, character varying, character varying, character varying, integer, boolean, integer, boolean); Type: FUNCTION; Schema: aoai; Owner: admin
 --
 
-CREATE FUNCTION aoai.add_event(p_entra_id character varying, p_event_code character varying, p_event_markdown character varying, p_start_utc timestamp without time zone, p_end_utc timestamp without time zone, p_organizer_name character varying, p_organizer_email character varying, p_event_url character varying, p_event_url_text character varying, p_daily_request_cap integer, p_active boolean) RETURNS TABLE(event_id character varying, owner_id uuid, event_code character varying, event_markdown character varying, start_utc timestamp without time zone, end_utc timestamp without time zone, organizer_name character varying, organizer_email character varying, event_url character varying, event_url_text character varying, daily_request_cap integer, active boolean)
+CREATE FUNCTION aoai.add_event(p_entra_id character varying, p_event_code character varying, p_event_markdown character varying, p_start_utc timestamp without time zone, p_end_utc timestamp without time zone, p_organizer_name character varying, p_organizer_email character varying, p_event_url character varying, p_event_url_text character varying, p_max_token_cap integer, p_single_code boolean, p_daily_request_cap integer, p_active boolean) RETURNS TABLE(event_id character varying, owner_id uuid, event_code character varying, event_markdown character varying, start_utc timestamp without time zone, end_utc timestamp without time zone, organizer_name character varying, organizer_email character varying, event_url character varying, event_url_text character varying, max_token_cap integer, single_code boolean, daily_request_cap integer, active boolean)
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -79,6 +79,8 @@ BEGIN
         organizer_email,
         event_url,
         event_url_text,
+        max_token_cap,
+        single_code,
         daily_request_cap,
         active
     )
@@ -93,6 +95,8 @@ BEGIN
 		p_organizer_email,
 		p_event_url,
 		p_event_url_text,
+		p_max_token_cap,
+		p_single_code,
 		p_daily_request_cap,
 		p_active
 		);
@@ -109,14 +113,14 @@ BEGIN
     );
 
 	RETURN QUERY
-	SELECT e.event_id, e.owner_id, e.event_code, e.event_markdown, e.start_utc, e.end_utc, e.organizer_name, e.organizer_email, e.event_url, e.event_url_text, e.daily_request_cap, e.active
+	SELECT e.event_id, e.owner_id, e.event_code, e.event_markdown, e.start_utc, e.end_utc, e.organizer_name, e.organizer_email, e.event_url, e.event_url_text, e.max_token_cap, e.single_code, e.daily_request_cap, e.active
 	FROM aoai.event as e WHERE e.event_id = v_final_hash;
 
 END;
 $$;
 
 
-ALTER FUNCTION aoai.add_event(p_entra_id character varying, p_event_code character varying, p_event_markdown character varying, p_start_utc timestamp without time zone, p_end_utc timestamp without time zone, p_organizer_name character varying, p_organizer_email character varying, p_event_url character varying, p_event_url_text character varying, p_daily_request_cap integer, p_active boolean) OWNER TO admin;
+ALTER FUNCTION aoai.add_event(p_entra_id character varying, p_event_code character varying, p_event_markdown character varying, p_start_utc timestamp without time zone, p_end_utc timestamp without time zone, p_organizer_name character varying, p_organizer_email character varying, p_event_url character varying, p_event_url_text character varying, p_max_token_cap integer, p_single_code boolean, p_daily_request_cap integer, p_active boolean) OWNER TO admin;
 
 --
 -- Name: add_event_attendee(character varying, character varying); Type: FUNCTION; Schema: aoai; Owner: admin
@@ -148,7 +152,7 @@ ALTER FUNCTION aoai.add_event_attendee(p_user_id character varying, p_event_id c
 -- Name: get_attendee_authorized(character varying, uuid); Type: FUNCTION; Schema: aoai; Owner: admin
 --
 
-CREATE FUNCTION aoai.get_attendee_authorized(p_event_code character varying, p_api_key uuid) RETURNS TABLE(user_id character varying, event_id character varying, event_code character varying, organizer_name character varying, organizer_email character varying, event_url character varying, event_url_text character varying, daily_request_cap integer)
+CREATE FUNCTION aoai.get_attendee_authorized(p_event_code character varying, p_api_key uuid) RETURNS TABLE(user_id character varying, event_id character varying, event_code character varying, organizer_name character varying, organizer_email character varying, event_url character varying, event_url_text character varying, max_token_cap integer, daily_request_cap integer)
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -165,6 +169,7 @@ BEGIN
         E.organizer_email,
         E.event_url,
         E.event_url_text,
+        E.max_token_cap,
         E.daily_request_cap
     FROM
         aoai.event E
@@ -284,6 +289,8 @@ CREATE TABLE aoai.event (
     organizer_email character varying(128) NOT NULL,
     event_url character varying(256) NOT NULL,
     event_url_text character varying(256) NOT NULL,
+    max_token_cap integer NOT NULL,
+    single_code boolean NOT NULL,
     daily_request_cap integer NOT NULL,
     active boolean NOT NULL
 );

--- a/src/AzureOpenAIProxy.Management/AoaiProxyContext.cs
+++ b/src/AzureOpenAIProxy.Management/AoaiProxyContext.cs
@@ -58,6 +58,7 @@ public partial class AoaiProxyContext : DbContext
             entity.Property(e => e.EventUrlText)
                 .HasMaxLength(256)
                 .HasColumnName("event_url_text");
+            entity.Property(e => e.MaxTokenCap).HasColumnName("max_token_cap");
             entity.Property(e => e.OrganizerEmail)
                 .HasMaxLength(128)
                 .HasColumnName("organizer_email");
@@ -67,6 +68,7 @@ public partial class AoaiProxyContext : DbContext
             entity.Property(e => e.OwnerId)
                 .HasDefaultValueSql("gen_random_uuid()")
                 .HasColumnName("owner_id");
+            entity.Property(e => e.SingleCode).HasColumnName("single_code");
             entity.Property(e => e.StartUtc)
                 .HasColumnType("timestamp(6) without time zone")
                 .HasColumnName("start_utc");

--- a/src/AzureOpenAIProxy.Management/AoaiProxyContext.cs
+++ b/src/AzureOpenAIProxy.Management/AoaiProxyContext.cs
@@ -68,7 +68,6 @@ public partial class AoaiProxyContext : DbContext
             entity.Property(e => e.OwnerId)
                 .HasDefaultValueSql("gen_random_uuid()")
                 .HasColumnName("owner_id");
-            entity.Property(e => e.SingleCode).HasColumnName("single_code");
             entity.Property(e => e.StartUtc)
                 .HasColumnType("timestamp(6) without time zone")
                 .HasColumnName("start_utc");

--- a/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditor.razor
+++ b/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditor.razor
@@ -28,10 +28,7 @@
                     For="@(() => Model.MaxTokenCap)" />
                 <MudNumericField Label="Daily Request Cap" @bind-Value="Model.DailyRequestCap" Min="0"
                     For="@(() => Model.DailyRequestCap)" />
-            </div>
-            <div class="d-flex">
                 <MudSwitch @bind-Value="Model.Active" Label="Active" Color="Color.Primary" />
-                <MudSwitch @bind-Value="Model.SingleCode" Label="Single Code" />
             </div>
         </MudCardContent>
         <MudCardActions>

--- a/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditor.razor
+++ b/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditor.razor
@@ -24,9 +24,14 @@
             <MudTextField Label="Description" @bind-Value="Model.Description" Lines="10"
                 For="@(() => Model.Description)" />
             <div class="d-flex">
+                <MudNumericField Label="Max Tokens" @bind-Value="Model.MaxTokenCap" Min="0"
+                    For="@(() => Model.MaxTokenCap)" />
                 <MudNumericField Label="Daily Request Cap" @bind-Value="Model.DailyRequestCap" Min="0"
                     For="@(() => Model.DailyRequestCap)" />
+            </div>
+            <div class="d-flex">
                 <MudSwitch @bind-Value="Model.Active" Label="Active" Color="Color.Primary" />
+                <MudSwitch @bind-Value="Model.SingleCode" Label="Single Code" />
             </div>
         </MudCardContent>
         <MudCardActions>

--- a/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditorModel.cs
+++ b/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditorModel.cs
@@ -27,6 +27,10 @@ public class EventEditorModel
     [StringLength(128)]
     [EmailAddress]
     public string? OrganizerEmail { get; set; }
+    [Required(ErrorMessage = "Specify the maximum number of tokens allowed per request")]
+    public int MaxTokenCap { get; set; } = 4096;
+    [Required]
+    public bool SingleCode { get; set; }
     [Required(ErrorMessage = "Specify the maximum number of requests allowed per day per token")]
     public int DailyRequestCap { get; set; } = 10000;
     public bool Active { get; set; }

--- a/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditorModel.cs
+++ b/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditorModel.cs
@@ -29,8 +29,6 @@ public class EventEditorModel
     public string? OrganizerEmail { get; set; }
     [Required(ErrorMessage = "Specify the maximum number of tokens allowed per request")]
     public int MaxTokenCap { get; set; } = 4096;
-    [Required]
-    public bool SingleCode { get; set; }
     [Required(ErrorMessage = "Specify the maximum number of requests allowed per day per token")]
     public int DailyRequestCap { get; set; } = 10000;
     public bool Active { get; set; }

--- a/src/AzureOpenAIProxy.Management/Components/Pages/EventEdit.razor.cs
+++ b/src/AzureOpenAIProxy.Management/Components/Pages/EventEdit.razor.cs
@@ -60,7 +60,9 @@ public partial class EventEdit : ComponentBase
             OrganizerEmail = evt.OrganizerEmail,
             OrganizerName = evt.OrganizerName,
             Active = evt.Active,
+            MaxTokenCap = evt.MaxTokenCap,
             DailyRequestCap = evt.DailyRequestCap,
+            SingleCode = evt.SingleCode,
         };
     }
 

--- a/src/AzureOpenAIProxy.Management/Components/Pages/EventEdit.razor.cs
+++ b/src/AzureOpenAIProxy.Management/Components/Pages/EventEdit.razor.cs
@@ -62,7 +62,6 @@ public partial class EventEdit : ComponentBase
             Active = evt.Active,
             MaxTokenCap = evt.MaxTokenCap,
             DailyRequestCap = evt.DailyRequestCap,
-            SingleCode = evt.SingleCode,
         };
     }
 

--- a/src/AzureOpenAIProxy.Management/Database/Event.cs
+++ b/src/AzureOpenAIProxy.Management/Database/Event.cs
@@ -24,8 +24,6 @@ public partial class Event
 
     public int MaxTokenCap { get; set; }
 
-    public bool SingleCode { get; set; }
-
     public int DailyRequestCap { get; set; }
 
     public bool Active { get; set; }

--- a/src/AzureOpenAIProxy.Management/Database/Event.cs
+++ b/src/AzureOpenAIProxy.Management/Database/Event.cs
@@ -22,6 +22,10 @@ public partial class Event
 
     public string EventUrlText { get; set; } = null!;
 
+    public int MaxTokenCap { get; set; }
+
+    public bool SingleCode { get; set; }
+
     public int DailyRequestCap { get; set; }
 
     public bool Active { get; set; }

--- a/src/AzureOpenAIProxy.Management/Services/EventService.cs
+++ b/src/AzureOpenAIProxy.Management/Services/EventService.cs
@@ -20,6 +20,8 @@ public class EventService(IAuthService authService, AoaiProxyContext db) : IEven
             EndUtc = model.End!.Value,
             OrganizerName = model.OrganizerName!,
             OrganizerEmail = model.OrganizerEmail!,
+            MaxTokenCap = model.MaxTokenCap,
+            SingleCode = model.SingleCode,
             DailyRequestCap = model.DailyRequestCap,
             Active = model.Active
         };
@@ -30,7 +32,7 @@ public class EventService(IAuthService authService, AoaiProxyContext db) : IEven
         await conn.OpenAsync();
         using DbCommand cmd = conn.CreateCommand();
 
-        cmd.CommandText = $"SELECT * FROM aoai.add_event(@EntraId, @EventCode, @EventMarkdown, @StartUtc, @EndUtc, @OrganiserName, @OrganiserEmail, @EventUrl, @EventUrlText, @DailyRequestCap, @Active)";
+        cmd.CommandText = $"SELECT * FROM aoai.add_event(@EntraId, @EventCode, @EventMarkdown, @StartUtc, @EndUtc, @OrganiserName, @OrganiserEmail, @EventUrl, @EventUrlText, @MaxTokenCap, @SingleCode, @DailyRequestCap, @Active)";
 
         cmd.Parameters.Add(new NpgsqlParameter("EntraId", entraId));
         cmd.Parameters.Add(new NpgsqlParameter("EventCode", newEvent.EventCode));
@@ -41,6 +43,8 @@ public class EventService(IAuthService authService, AoaiProxyContext db) : IEven
         cmd.Parameters.Add(new NpgsqlParameter("OrganiserEmail", newEvent.OrganizerEmail));
         cmd.Parameters.Add(new NpgsqlParameter("EventUrl", newEvent.EventUrl));
         cmd.Parameters.Add(new NpgsqlParameter("EventUrlText", newEvent.EventUrlText));
+        cmd.Parameters.Add(new NpgsqlParameter("MaxTokenCap", newEvent.MaxTokenCap));
+        cmd.Parameters.Add(new NpgsqlParameter("SingleCode", newEvent.SingleCode));
         cmd.Parameters.Add(new NpgsqlParameter("DailyRequestCap", newEvent.DailyRequestCap));
         cmd.Parameters.Add(new NpgsqlParameter("Active", newEvent.Active));
 
@@ -83,7 +87,9 @@ public class EventService(IAuthService authService, AoaiProxyContext db) : IEven
         evt.OrganizerEmail = model.OrganizerEmail!;
         evt.OrganizerName = model.OrganizerName!;
         evt.Active = model.Active;
+        evt.MaxTokenCap = model.MaxTokenCap;
         evt.DailyRequestCap = model.DailyRequestCap;
+        evt.SingleCode = model.SingleCode;
 
         await db.SaveChangesAsync();
 

--- a/src/AzureOpenAIProxy.Management/Services/EventService.cs
+++ b/src/AzureOpenAIProxy.Management/Services/EventService.cs
@@ -21,7 +21,6 @@ public class EventService(IAuthService authService, AoaiProxyContext db) : IEven
             OrganizerName = model.OrganizerName!,
             OrganizerEmail = model.OrganizerEmail!,
             MaxTokenCap = model.MaxTokenCap,
-            SingleCode = model.SingleCode,
             DailyRequestCap = model.DailyRequestCap,
             Active = model.Active
         };
@@ -32,7 +31,7 @@ public class EventService(IAuthService authService, AoaiProxyContext db) : IEven
         await conn.OpenAsync();
         using DbCommand cmd = conn.CreateCommand();
 
-        cmd.CommandText = $"SELECT * FROM aoai.add_event(@EntraId, @EventCode, @EventMarkdown, @StartUtc, @EndUtc, @OrganiserName, @OrganiserEmail, @EventUrl, @EventUrlText, @MaxTokenCap, @SingleCode, @DailyRequestCap, @Active)";
+        cmd.CommandText = $"SELECT * FROM aoai.add_event(@EntraId, @EventCode, @EventMarkdown, @StartUtc, @EndUtc, @OrganiserName, @OrganiserEmail, @EventUrl, @EventUrlText, @MaxTokenCap, @DailyRequestCap, @Active)";
 
         cmd.Parameters.Add(new NpgsqlParameter("EntraId", entraId));
         cmd.Parameters.Add(new NpgsqlParameter("EventCode", newEvent.EventCode));
@@ -44,7 +43,6 @@ public class EventService(IAuthService authService, AoaiProxyContext db) : IEven
         cmd.Parameters.Add(new NpgsqlParameter("EventUrl", newEvent.EventUrl));
         cmd.Parameters.Add(new NpgsqlParameter("EventUrlText", newEvent.EventUrlText));
         cmd.Parameters.Add(new NpgsqlParameter("MaxTokenCap", newEvent.MaxTokenCap));
-        cmd.Parameters.Add(new NpgsqlParameter("SingleCode", newEvent.SingleCode));
         cmd.Parameters.Add(new NpgsqlParameter("DailyRequestCap", newEvent.DailyRequestCap));
         cmd.Parameters.Add(new NpgsqlParameter("Active", newEvent.Active));
 
@@ -89,7 +87,6 @@ public class EventService(IAuthService authService, AoaiProxyContext db) : IEven
         evt.Active = model.Active;
         evt.MaxTokenCap = model.MaxTokenCap;
         evt.DailyRequestCap = model.DailyRequestCap;
-        evt.SingleCode = model.SingleCode;
 
         await db.SaveChangesAsync();
 


### PR DESCRIPTION
Reverts the change to remove `max_token_cap` (#81) but still removes `single_code` (Fixes #80)