### PR TITLE
Verifying azd

### DIFF
--- a/.github/workflows/azd-ci.yaml
+++ b/.github/workflows/azd-ci.yaml
@@ -1,0 +1,24 @@
+name: azd package
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main", "feature/*"]
+
+env:
+  DOTNET_VERSION: 8.0.x
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install azd
+        uses: Azure/setup-azd@v0.1.0
+
+      - name: Package with azd
+        run: azd package

--- a/.github/workflows/azd-ci.yaml
+++ b/.github/workflows/azd-ci.yaml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: ["main", "feature/*"]
 
-env:
-  DOTNET_VERSION: 8.0.x
-
 jobs:
   package:
     runs-on: ubuntu-latest
@@ -19,6 +16,9 @@ jobs:
 
       - name: Install azd
         uses: Azure/setup-azd@v0.1.0
+
+      - name: Setup an azd env
+        run: azd env new ci
 
       - name: Package with azd
         run: azd package


### PR DESCRIPTION
This will run `azd package` which builds all the artifacts but doesn't provision infrastructure or deploy.

Used to ensure that everything is buildable for azd on push.