### PR TITLE
Storing the start/end dates as UTC not local

### DIFF
--- a/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditor.razor
+++ b/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditor.razor
@@ -20,6 +20,13 @@
                     For="@(() => Model.Start)" Format="s" />
                 <MudTextField Label="End Date" @bind-Value="Model.End" InputType="InputType.DateTimeLocal"
                     For="@(() => Model.End)" Format="s" />
+
+                <MudSelect @bind-Value="Model.SelectedTimeZone" Label="Time Zone" FullWidth="true" For="@(() => Model.SelectedTimeZone)">
+                @foreach (var timeZone in TimeZones)
+                {
+                    <MudSelectItem Value="@timeZone">@timeZone</MudSelectItem>
+                }
+                </MudSelect>
             </div>
             <MudTextField Label="Description" @bind-Value="Model.Description" Lines="10"
                 For="@(() => Model.Description)" />

--- a/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditor.razor.cs
+++ b/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditor.razor.cs
@@ -20,12 +20,15 @@ public partial class EventEditor : ComponentBase
 
     private bool isSubmitting = false;
 
+    private IEnumerable<TimeZoneInfo>? TimeZones { get; set; }
+
     protected override Task OnInitializedAsync()
     {
         Model ??= new();
         editContext = new(Model);
         editContext.OnValidationRequested += EditContext_OnValidationRequested;
         messageStore = new(editContext);
+        TimeZones = TimeZoneInfo.GetSystemTimeZones();
         return Task.CompletedTask;
     }
 
@@ -48,6 +51,12 @@ public partial class EventEditor : ComponentBase
         {
             return;
         }
+
+        DateTimeOffset startWithTimezone = new(Model.Start!.Value, Model.SelectedTimeZone!.GetUtcOffset(Model.Start!.Value));
+        DateTimeOffset endWithTimezone = new(Model.End!.Value, Model.SelectedTimeZone!.GetUtcOffset(Model.End!.Value));
+
+        Model.Start = new DateTime(startWithTimezone.UtcDateTime.Ticks, DateTimeKind.Unspecified);
+        Model.End = new DateTime(endWithTimezone.UtcDateTime.Ticks, DateTimeKind.Unspecified);
 
         isSubmitting = true;
         await OnValidSubmit.InvokeAsync(Model);

--- a/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditorModel.cs
+++ b/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditorModel.cs
@@ -32,4 +32,7 @@ public class EventEditorModel
     [Required(ErrorMessage = "Specify the maximum number of requests allowed per day per token")]
     public int DailyRequestCap { get; set; } = 10000;
     public bool Active { get; set; }
+
+    [Required(ErrorMessage = "Time zone is required")]
+    public TimeZoneInfo? SelectedTimeZone { get; set; }
 }


### PR DESCRIPTION
Fixes #124

Probably not the most elegant fix, but the problem is that the DateTime object from the client is DateTimeKind.Unspecified, so we can't directly convert that to UTC (conversion thinks it is when it's actually local time), so we need to know the time zone that it was in, convert it to a DateTimeOffset, and then we have to convert it back to a DateTime object with a DateTimeKind of Unspecified so that Postgres doesn't try to serialize a timezone into it, since the database columns are timestamp without timezone.