### PR TITLE
Update app registration cleanup script

### DIFF
--- a/infra/scripts/cleanup-app-registration.sh
+++ b/infra/scripts/cleanup-app-registration.sh
@@ -16,9 +16,12 @@ done <<EOF
 $(azd env get-values)
 EOF
 
-if [[ -z "${AUTH_TENANT_ID}" ]]; then
-    echo "AUTH_TENANT_ID is not set. No app to delete."
+if [[ -z "${AUTH_CLIENT_ID}" ]]; then
+    echo "AUTH_CLIENT_ID is not set. No app to delete."
 fi
 
-echo Deleting app registration for $AUTH_TENANT_ID
-az ad app delete --id $AUTH_TENANT_ID
+echo Deleting app registration for $AUTH_CLIENT_ID
+az ad app delete --id $AUTH_CLIENT_ID
+
+azd env set AUTH_CLIENT_ID ""
+azd env set AUTH_TENANT_ID ""


### PR DESCRIPTION
This pull request updates the app registration cleanup script to delete the app registration using the AUTH_CLIENT_ID instead of the AUTH_TENANT_ID. It also sets the AUTH_CLIENT_ID and AUTH_TENANT_ID environment variables to empty strings in the Azure DevOps environment.