### PR TITLE
Refactor ChatCard component and Chat reducers for better error handling

### DIFF
--- a/src/playground/src/components/playground/ChatCard.tsx
+++ b/src/playground/src/components/playground/ChatCard.tsx
@@ -14,10 +14,11 @@ import { Response } from "./Response";
 import { useEventDataContext } from "../../providers/EventDataProvider";
 import type { ChatMessage } from "@azure/openai";
 import { Card } from "./Card";
+import { ChatMessageExtended } from "../../pages/playground/Chat.state";
 
 interface CardProps {
   onPromptEntered: (messages: ChatMessage[]) => void;
-  messageList: ChatMessage[];
+  messageList: ChatMessageExtended[];
   onClear: () => void;
   isLoading: boolean;
 }
@@ -93,7 +94,7 @@ export const ChatCard = ({
         <ChatInput
           promptSubmitted={(userPrompt) => {
             onPromptEntered([
-              ...messageList,
+              ...messageList.filter((m) => !m.isError),
               { role: "user", content: userPrompt },
             ]);
           }}

--- a/src/playground/src/pages/playground/Chat.state.ts
+++ b/src/playground/src/pages/playground/Chat.state.ts
@@ -1,16 +1,21 @@
 import { ChatMessage, GetChatCompletionsOptions } from "@azure/openai";
 import { UsageData } from "../../interfaces/UsageData";
 
-const defaultSysPrompt: ChatMessage = {
+const defaultSysPrompt: ChatMessageExtended = {
   role: "system",
   content: "You are an AI assistant that helps people find information.",
+  isError: false,
 };
+
+export type ChatMessageExtended = ChatMessage & {
+  isError: boolean;
+}
 
 export type ChatState = {
   isLoading: boolean;
   params: GetChatCompletionsOptions;
   usageData: UsageData;
-  messages: ChatMessage[];
+  messages: ChatMessageExtended[];
 };
 
 export const INITIAL_STATE: ChatState = {


### PR DESCRIPTION
This pull request refactors the ChatCard component and Chat reducers to improve error handling. It introduces a new type `ChatMessageExtended` that extends `ChatMessage` and includes an `isError` property. The `ChatCard` component now filters out error messages when submitting a user prompt. The `reducer` function handles error messages separately and updates the `messages` array with the `isError` property set accordingly. This improves the overall error handling in the Chat feature.

Fixes #135
Fixes #133