### PR TITLE
Displaying the right time zone when editing events

### DIFF
--- a/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditor.razor.cs
+++ b/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditor.razor.cs
@@ -52,12 +52,6 @@ public partial class EventEditor : ComponentBase
             return;
         }
 
-        DateTimeOffset startWithTimezone = new(Model.Start!.Value, Model.SelectedTimeZone!.GetUtcOffset(Model.Start!.Value));
-        DateTimeOffset endWithTimezone = new(Model.End!.Value, Model.SelectedTimeZone!.GetUtcOffset(Model.End!.Value));
-
-        Model.Start = new DateTime(startWithTimezone.UtcDateTime.Ticks, DateTimeKind.Unspecified);
-        Model.End = new DateTime(endWithTimezone.UtcDateTime.Ticks, DateTimeKind.Unspecified);
-
         isSubmitting = true;
         await OnValidSubmit.InvokeAsync(Model);
         isSubmitting = false;

--- a/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditorModel.cs
+++ b/src/AzureOpenAIProxy.Management/Components/EventManagement/EventEditorModel.cs
@@ -49,4 +49,16 @@ public class EventEditorModel
 
     [Required(ErrorMessage = "Time zone is required")]
     public TimeZoneInfo? SelectedTimeZone { get; set; }
+
+    public DateTime StartUtc()
+    {
+        DateTimeOffset s = new(Start!.Value, SelectedTimeZone!.GetUtcOffset(Start!.Value));
+        return new DateTime(s.UtcDateTime.Ticks, DateTimeKind.Unspecified);
+    }
+
+    public DateTime EndUtc()
+    {
+        DateTimeOffset e = new(End!.Value, SelectedTimeZone!.GetUtcOffset(End!.Value));
+        return new DateTime(e.UtcDateTime.Ticks, DateTimeKind.Unspecified);
+    }
 }

--- a/src/AzureOpenAIProxy.Management/Components/Pages/EventEdit.razor.cs
+++ b/src/AzureOpenAIProxy.Management/Components/Pages/EventEdit.razor.cs
@@ -62,6 +62,11 @@ public partial class EventEdit : ComponentBase
         Model.MaxTokenCap = evt.MaxTokenCap;
         Model.DailyRequestCap = evt.DailyRequestCap;
         Model.SelectedTimeZone = TimeZoneInfo.FindSystemTimeZoneById(evt.TimeZoneLabel);
+
+        DateTimeOffset start = TimeZoneInfo.ConvertTimeFromUtc(evt.StartTimestamp, Model.SelectedTimeZone);
+        DateTimeOffset end = TimeZoneInfo.ConvertTimeFromUtc(evt.EndTimestamp, Model.SelectedTimeZone);
+        Model.Start = start.DateTime;
+        Model.End = end.DateTime;
     }
 
     private async Task OnValidSubmit(EventEditorModel model)

--- a/src/AzureOpenAIProxy.Management/Services/EventService.cs
+++ b/src/AzureOpenAIProxy.Management/Services/EventService.cs
@@ -19,8 +19,8 @@ public class EventService(IAuthService authService, AoaiProxyContext db) : IEven
             EventUrl = model.Url!,
             EventImageUrl = model.EventImageUrl!,
             EventMarkdown = model.Description!,
-            StartTimestamp = model.Start!.Value,
-            EndTimestamp = model.End!.Value,
+            StartTimestamp = model.StartUtc(),
+            EndTimestamp = model.EndUtc(),
             TimeZoneOffset = model.SelectedTimeZone!.BaseUtcOffset.Minutes,
             TimeZoneLabel = model.SelectedTimeZone!.Id,
             OrganizerName = model.OrganizerName!,
@@ -93,8 +93,8 @@ public class EventService(IAuthService authService, AoaiProxyContext db) : IEven
 
         evt.EventCode = model.Name!;
         evt.EventMarkdown = model.Description!;
-        evt.StartTimestamp = model.Start!.Value;
-        evt.EndTimestamp = model.End!.Value;
+        evt.StartTimestamp = model.StartUtc();
+        evt.EndTimestamp = model.EndUtc();
         evt.EventUrl = model.Url!;
         evt.EventUrlText = model.UrlText!;
         evt.EventImageUrl = model.EventImageUrl!;


### PR DESCRIPTION
We weren't applying the selected timezone when retrieving the event back in the admin UI, so it was always showing UTC value.

Also tweaked it a little so that we don't mess with the model before submitting, instead we have computed property which is the UTC start/end date to be passed into the database calls

Fixes #161