### PR TITLE
Reverting a change for handling event data loading

### DIFF
--- a/src/playground/src/providers/EventDataProvider.tsx
+++ b/src/playground/src/providers/EventDataProvider.tsx
@@ -103,7 +103,7 @@ const EventDataProvider: React.FC<PropsWithChildren> = ({ children }) => {
         eventCode,
       }}
     >
-      {eventData && children}
+      {children}
     </EventDataContext.Provider>
   );
 };


### PR DESCRIPTION
The problem is more that the eventData API call throws an error that then results in no eventData being set, rather than returning something that indicates an error. Need to better work out how to wait until the data is loaded or not