### PR TITLE
Add a "usage" field in aoai.metric to record token usages

### DIFF
--- a/database/aoai-proxy.sql
+++ b/database/aoai-proxy.sql
@@ -58,10 +58,10 @@ CREATE TYPE aoai.model_type AS ENUM (
 ALTER TYPE aoai.model_type OWNER TO azure_pg_admin;
 
 --
--- Name: add_attendee_metric(character varying, character varying, uuid); Type: PROCEDURE; Schema: aoai; Owner: azure_pg_admin
+-- Name: add_attendee_metric(character varying, character varying, uuid, character varying); Type: PROCEDURE; Schema: aoai; Owner: azure_pg_admin
 --
 
-CREATE PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid)
+CREATE PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid, IN p_usage character varying)
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -85,13 +85,13 @@ BEGIN
 
     SELECT model_type || ' | ' || deployment_name INTO v_resource_string FROM aoai.owner_catalog as oc WHERE oc.catalog_id = p_catalog_id;
 
-    INSERT INTO aoai.metric(api_key, event_id, resource)
-    VALUES (p_api_key, p_event_id, v_resource_string);
+    INSERT INTO aoai.metric(api_key, event_id, resource, usage)
+    VALUES (p_api_key, p_event_id, v_resource_string, p_usage);
 END;
 $$;
 
 
-ALTER PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid) OWNER TO azure_pg_admin;
+ALTER PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid, IN p_usage character varying) OWNER TO azure_pg_admin;
 
 --
 -- Name: add_event(character varying, character varying, character varying, timestamp without time zone, timestamp without time zone, integer, character varying, character varying, character varying, character varying, character varying, integer, integer, boolean, character varying); Type: FUNCTION; Schema: aoai; Owner: azure_pg_admin
@@ -421,7 +421,8 @@ CREATE TABLE aoai.metric (
     api_key character varying NOT NULL,
     date_stamp date DEFAULT CURRENT_DATE NOT NULL,
     time_stamp time without time zone DEFAULT CURRENT_TIME NOT NULL,
-    resource character varying(64) NOT NULL
+    resource character varying(64) NOT NULL,
+    usage character varying(255)
 );
 
 

--- a/database/aoai-proxy.sql
+++ b/database/aoai-proxy.sql
@@ -58,10 +58,10 @@ CREATE TYPE aoai.model_type AS ENUM (
 ALTER TYPE aoai.model_type OWNER TO azure_pg_admin;
 
 --
--- Name: add_attendee_metric(character varying, character varying, uuid, character varying); Type: PROCEDURE; Schema: aoai; Owner: azure_pg_admin
+-- Name: add_attendee_metric(character varying, character varying, uuid, character varying, JSONB); Type: PROCEDURE; Schema: aoai; Owner: azure_pg_admin
 --
 
-CREATE PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid, IN p_usage character varying)
+CREATE PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid, IN p_usage JSONB)
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -91,7 +91,7 @@ END;
 $$;
 
 
-ALTER PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid, IN p_usage character varying) OWNER TO azure_pg_admin;
+ALTER PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid, IN p_usage JSONB) OWNER TO azure_pg_admin;
 
 --
 -- Name: add_event(character varying, character varying, character varying, timestamp without time zone, timestamp without time zone, integer, character varying, character varying, character varying, character varying, character varying, integer, integer, boolean, character varying); Type: FUNCTION; Schema: aoai; Owner: azure_pg_admin
@@ -422,7 +422,7 @@ CREATE TABLE aoai.metric (
     date_stamp date DEFAULT CURRENT_DATE NOT NULL,
     time_stamp time without time zone DEFAULT CURRENT_TIME NOT NULL,
     resource character varying(64) NOT NULL,
-    usage character varying(255)
+    usage JSONB
 );
 
 

--- a/database/aoai-proxy.sql
+++ b/database/aoai-proxy.sql
@@ -58,24 +58,27 @@ CREATE TYPE aoai.model_type AS ENUM (
 ALTER TYPE aoai.model_type OWNER TO azure_pg_admin;
 
 --
--- Name: add_attendee_metric(character varying, character varying, uuid, character varying, JSONB); Type: PROCEDURE; Schema: aoai; Owner: azure_pg_admin
+-- Name: add_attendee_metric(character varying, character varying, uuid, jsonb); Type: PROCEDURE; Schema: aoai; Owner: azure_pg_admin
 --
 
-CREATE PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid, IN p_usage JSONB)
+CREATE PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid, IN p_usage jsonb)
     LANGUAGE plpgsql
     AS $$
 DECLARE
 	v_resource_string VARCHAR(64);
+	v_token_count INTEGER;
 BEGIN
 --     PERFORM request_count FROM aoai.event_attendee_request
 --     WHERE api_key = p_api_key AND date_stamp = CURRENT_DATE;
+
+	v_token_count = COALESCE((p_usage ->> 'total_tokens')::integer, 0);
 
     IF EXISTS
 		(SELECT 1 FROM aoai.event_attendee_request WHERE api_key = p_api_key AND date_stamp = CURRENT_DATE)
 	THEN
         -- If a record exists, increment the count
         UPDATE aoai.event_attendee_request
-        SET request_count = request_count + 1
+        SET request_count = request_count + 1, token_count = token_count + v_token_count
         WHERE api_key = p_api_key AND date_stamp = CURRENT_DATE;
     ELSE
         -- If no record exists, insert a new one with count set to 1
@@ -91,7 +94,7 @@ END;
 $$;
 
 
-ALTER PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid, IN p_usage JSONB) OWNER TO azure_pg_admin;
+ALTER PROCEDURE aoai.add_attendee_metric(IN p_api_key character varying, IN p_event_id character varying, IN p_catalog_id uuid, IN p_usage jsonb) OWNER TO azure_pg_admin;
 
 --
 -- Name: add_event(character varying, character varying, character varying, timestamp without time zone, timestamp without time zone, integer, character varying, character varying, character varying, character varying, character varying, integer, integer, boolean, character varying); Type: FUNCTION; Schema: aoai; Owner: azure_pg_admin
@@ -394,7 +397,8 @@ ALTER TABLE aoai.event_attendee OWNER TO azure_pg_admin;
 CREATE TABLE aoai.event_attendee_request (
     api_key character varying NOT NULL,
     date_stamp date NOT NULL,
-    request_count integer NOT NULL
+    request_count integer NOT NULL,
+    token_count integer NOT NULL
 );
 
 
@@ -422,7 +426,7 @@ CREATE TABLE aoai.metric (
     date_stamp date DEFAULT CURRENT_DATE NOT NULL,
     time_stamp time without time zone DEFAULT CURRENT_TIME NOT NULL,
     resource character varying(64) NOT NULL,
-    usage JSONB
+    usage jsonb NOT NULL
 );
 
 

--- a/database/aoai-proxy.sql
+++ b/database/aoai-proxy.sql
@@ -82,8 +82,8 @@ BEGIN
         WHERE api_key = p_api_key AND date_stamp = CURRENT_DATE;
     ELSE
         -- If no record exists, insert a new one with count set to 1
-        INSERT INTO aoai.event_attendee_request(api_key, date_stamp, request_count)
-        VALUES (p_api_key, CURRENT_DATE, 1);
+        INSERT INTO aoai.event_attendee_request(api_key, date_stamp, request_count, token_count)
+        VALUES (p_api_key, CURRENT_DATE, 1, v_token_count);
     END IF;
 
     SELECT model_type || ' | ' || deployment_name INTO v_resource_string FROM aoai.owner_catalog as oc WHERE oc.catalog_id = p_catalog_id;

--- a/src/proxy/app/config.py
+++ b/src/proxy/app/config.py
@@ -128,8 +128,6 @@ class Config:
 
         authorize_response.catalog_id = deployments[index].catalog_id
 
-        await self.monitor.log_api_call(entity=authorize_response)
-
         return deployments[index]
 
     async def get_event_deployments(self, authorize_response: AuthorizeResponse) -> list[str]:

--- a/src/proxy/app/monitor.py
+++ b/src/proxy/app/monitor.py
@@ -30,6 +30,7 @@ class MonitorEntity(BaseModel):
     deployment_name: str
     api_key: str
     catalog_id: UUID | None = None
+    usage: str | None = '{}'
 
     def __init__(
         self,
@@ -47,6 +48,7 @@ class MonitorEntity(BaseModel):
         deployment_name: str,
         api_key: str,
         catalog_id: UUID | None = None,
+        usage: str | None = '{}'
     ) -> None:
         super().__init__(
             is_authorized=is_authorized,
@@ -63,6 +65,7 @@ class MonitorEntity(BaseModel):
             deployment_name=deployment_name,
             api_key=api_key,
             catalog_id=catalog_id,
+            usage=usage,
         )
 
 
@@ -92,10 +95,11 @@ class Monitor:
         try:
             async with pool.acquire() as conn:
                 await conn.execute(
-                    "CALL aoai.add_attendee_metric($1, $2, $3)",
+                    "CALL aoai.add_attendee_metric($1, $2, $3, $4)",
                     entity.api_key,
                     entity.event_id,
                     entity.catalog_id,
+                    entity.usage,
                 )
 
         except asyncpg.exceptions.PostgresError as error:

--- a/src/proxy/app/monitor.py
+++ b/src/proxy/app/monitor.py
@@ -6,7 +6,8 @@ from uuid import UUID
 
 import asyncpg
 from fastapi import HTTPException
-from pydantic import BaseModel
+from typing import Any
+from pydantic import BaseModel, Json
 
 from .db_manager import DBManager
 
@@ -30,7 +31,7 @@ class MonitorEntity(BaseModel):
     deployment_name: str
     api_key: str
     catalog_id: UUID | None = None
-    usage: str | None = '{}'
+    usage: Json[Any] | None = '{}'
 
     def __init__(
         self,
@@ -48,7 +49,7 @@ class MonitorEntity(BaseModel):
         deployment_name: str,
         api_key: str,
         catalog_id: UUID | None = None,
-        usage: str | None = '{}'
+        usage: Json[Any] | None = '{}'
     ) -> None:
         super().__init__(
             is_authorized=is_authorized,

--- a/src/proxy/app/routes/event_info.py
+++ b/src/proxy/app/routes/event_info.py
@@ -78,6 +78,7 @@ class EventInfo(RequestManager):
             del event_info_dict["daily_request_cap"]
             del event_info_dict["api_key"]
             del event_info_dict["catalog_id"]
+            del event_info_dict["usage"]
 
             return EventInfoResponse(**event_info_dict)
 

--- a/src/proxy/app/routes/event_info.py
+++ b/src/proxy/app/routes/event_info.py
@@ -70,16 +70,19 @@ class EventInfo(RequestManager):
                 authorize_response=authorize_response
             )
 
-            event_info_dict = dict(authorize_response)
-            event_info_dict["capabilities"] = capabilities
-            del event_info_dict["user_id"]
-            del event_info_dict["event_id"]
-            del event_info_dict["deployment_name"]
-            del event_info_dict["daily_request_cap"]
-            del event_info_dict["api_key"]
-            del event_info_dict["catalog_id"]
-            del event_info_dict["usage"]
+            # create a new EventInfoResponse object from authorize_response
+            event_info_response = EventInfoResponse(
+                is_authorized=authorize_response.is_authorized,
+                max_token_cap=authorize_response.max_token_cap,
+                event_code=authorize_response.event_code,
+                event_url=authorize_response.event_url,
+                event_url_text=authorize_response.event_url_text,
+                event_image_url=authorize_response.event_image_url,
+                organizer_name=authorize_response.organizer_name,
+                organizer_email=authorize_response.organizer_email,
+                capabilities=capabilities,
+            )
 
-            return EventInfoResponse(**event_info_dict)
+            return event_info_response
 
         return self.router

--- a/src/proxy/app/routes/request_manager.py
+++ b/src/proxy/app/routes/request_manager.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import AsyncGenerator
+import json
 
 from fastapi import APIRouter, HTTPException, Request
 
@@ -81,7 +82,7 @@ class RequestManager:
             response = self.model_to_dict(response)
             response["model"] = response["model"] + ":" + deployment.location.lower()
 
-        authorize_response.usage = str(response.get('usage', {}))
+        authorize_response.usage = json.dumps(response.get('usage', {}))
         await self.config.monitor.log_api_call(entity=authorize_response)
         return response, http_status_code
 

--- a/src/proxy/app/routes/request_manager.py
+++ b/src/proxy/app/routes/request_manager.py
@@ -81,6 +81,8 @@ class RequestManager:
             response = self.model_to_dict(response)
             response["model"] = response["model"] + ":" + deployment.location.lower()
 
+        authorize_response.usage = str(response.get('usage', {}))
+        await self.config.monitor.log_api_call(entity=authorize_response)
         return response, http_status_code
 
     def throw_validation_error(self, message: str, status_code: int):

--- a/src/proxy/app/routes/request_manager.py
+++ b/src/proxy/app/routes/request_manager.py
@@ -1,8 +1,8 @@
 """ Request Manager base class """
 
+import json
 import logging
 from collections.abc import AsyncGenerator
-import json
 
 from fastapi import APIRouter, HTTPException, Request
 
@@ -82,8 +82,9 @@ class RequestManager:
             response = self.model_to_dict(response)
             response["model"] = response["model"] + ":" + deployment.location.lower()
 
-        authorize_response.usage = json.dumps(response.get('usage', {}))
-        await self.config.monitor.log_api_call(entity=authorize_response)
+            authorize_response.usage = json.dumps(response.get("usage", {}))
+            await self.config.monitor.log_api_call(entity=authorize_response)
+
         return response, http_status_code
 
     def throw_validation_error(self, message: str, status_code: int):


### PR DESCRIPTION
Currently, aoai.metric only records time and deployment name. 
It would be useful for cost monitoring,  if the server can also record the token usage for each request.

This patch updated the related table schema and procedures to include one additional field "usage" to record the token usage info. The logging call was also moved into request_manager.py, so that it executes after the usage is available.

![Screenshot 2024-03-19 at 3 53 40 PM](https://github.com/microsoft/azure-openai-service-proxy/assets/831790/3a6e4b57-0732-451a-b02e-7b18b6238c48)
