### PR TITLE
Update docker-compose.yml

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   devcontainer:
-    image: mcr.microsoft.com/devcontainers/base:bullseye
+    image: mcr.microsoft.com/devcontainers/base:bookworm
     volumes:
       - ../..:/workspaces:cached
     network_mode: service:db


### PR DESCRIPTION
Updated base image to bookworm to support azd 1.8.0 with a requirement of glibc 2.32