### PR TITLE
Refactor Bicep file for db creation and schema deployment

### DIFF
--- a/infra/admin.bicep
+++ b/infra/admin.bicep
@@ -2,12 +2,12 @@ param name string
 param location string = resourceGroup().location
 param tags object = {}
 
+@description('The name of the user assigned identity that the container app will used to connect to the container registraty')
 param identityName string
 param containerAppsEnvironmentName string
 param containerRegistryName string
 param serviceName string = 'admin'
 param exists bool
-param postgresUser string
 param postgresDatabase string
 param postgresServer string
 @secure()
@@ -53,7 +53,7 @@ module app 'core/host/container-app-upsert.bicep' = {
       }
       {
         name: 'postgres-connection-string'
-        value: 'Server=${postgresServer};Port=5432;User Id=${postgresUser};Database=${postgresDatabase};Ssl Mode=Require;'
+        value: 'Server=${postgresServer};Port=5432;User Id=${name};Database=${postgresDatabase};Ssl Mode=Require;'
       }
     ]
     env: [
@@ -89,7 +89,7 @@ module app 'core/host/container-app-upsert.bicep' = {
   }
 }
 
-output principalId string = adminIdentity.properties.principalId
-output name string = app.outputs.name
-output uri string = app.outputs.uri
-output imageName string = app.outputs.imageName
+output SERVICE_ADMIN_IDENTITY_PRINCIPAL_ID string = adminIdentity.properties.principalId
+output SERVICE_ADMIN_NAME string = app.outputs.name
+output SERVICE_ADMIN_URI string = app.outputs.uri
+output SERVICE_ADMIN_IMAGE_NAME string = app.outputs.imageName

--- a/infra/db-seed.bicep
+++ b/infra/db-seed.bicep
@@ -1,0 +1,91 @@
+param name string
+param location string
+
+param postgresDatabaseName string
+param adminSystemAssignedIdentity string
+param proxySystemAssignedIdentity string
+
+@description('Entra admin role name')
+param entraAdministratorName string = ''
+
+@secure()
+param entraAuthorizationToken string
+
+param postgresServerName string
+
+resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' existing = {
+  name: postgresServerName
+}
+
+resource sqlDeploymentScriptSetup 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: '${name}-deployment-script-setup'
+  dependsOn: [
+    postgresServer
+  ]
+  location: location
+  kind: 'AzureCLI'
+  properties: {
+    azCliVersion: '2.37.0'
+    retentionInterval: 'PT1H' // Retain the script resource for 1 hour after it ends running
+    timeout: 'PT5M' // Five minutes
+    cleanupPreference: 'OnSuccess'
+    environmentVariables: [
+      {
+        name: 'SQL_SETUP_SCRIPT'
+        value: loadTextContent('../database/setup.sql')
+      }
+      {
+        name: 'SQL_SCRIPT'
+        value: loadTextContent('../database/aoai-proxy.sql')
+      }
+      {
+        name: 'PG_USER'
+        value: entraAdministratorName
+      }
+      {
+        name: 'PG_DB'
+        value: postgresDatabaseName
+      }
+      {
+        name: 'PG_HOST'
+        value: postgresServer.properties.fullyQualifiedDomainName
+      }
+      {
+        name: 'PGPASSWORD'
+        value: entraAuthorizationToken
+      }
+      {
+        name: 'ADMIN_SYSTEM_ASSIGNED_IDENTITY'
+        value: adminSystemAssignedIdentity
+      }
+      {
+        name: 'PROXY_SYSTEM_ASSIGNED_IDENTITY'
+        value: proxySystemAssignedIdentity
+      }
+    ]
+
+    scriptContent: '''
+      #!/bin/bash
+
+      apk add postgresql-client
+
+      echo "Executing permissions setup script starting"
+      echo "$SQL_SETUP_SCRIPT" > ./setup.sql
+      cat ./setup.sql
+
+      psql -a -U "$PG_USER" -d "postgres" -h "$PG_HOST" -v PG_USER="$PG_USER" -v ADMIN_SYSTEM_ASSIGNED_IDENTITY="$ADMIN_SYSTEM_ASSIGNED_IDENTITY" -v PROXY_SYSTEM_ASSIGNED_IDENTITY="$PROXY_SYSTEM_ASSIGNED_IDENTITY" -w -f ./setup.sql
+      echo "Executing permissions setup script ended"
+
+      echo "Executing database setup script starting"
+      echo "$SQL_SCRIPT" > ./setup.sql
+      cat ./setup.sql
+
+      psql -a -U "$PG_USER" -d "aoai-proxy" -h "$PG_HOST" -w -f ./setup.sql
+      echo "Executing database setup script ended"
+
+      echo "Creating database schema aoai with permissions"
+      psql -a -U "$PG_USER" -d "aoai-proxy" -h "$PG_HOST" -c "REVOKE ALL ON ALL TABLES IN SCHEMA aoai FROM aoai_proxy_app; GRANT DELETE, INSERT, UPDATE, SELECT ON ALL TABLES IN SCHEMA aoai TO aoai_proxy_app; GRANT ALL ON SCHEMA aoai TO azure_pg_admin; GRANT USAGE ON SCHEMA aoai TO azuresu;"
+
+    '''
+  }
+}

--- a/infra/db.bicep
+++ b/infra/db.bicep
@@ -1,15 +1,8 @@
 param location string
 param tags object
 
-param postgresDatabaseName string
 param name string
 param authType string = 'Password'
-
-param adminSystemAssignedIdentity string
-param proxySystemAssignedIdentity string
-
-@secure()
-param entraAuthorizationToken string
 
 @description('Entra admin role name')
 param entraAdministratorName string = ''
@@ -61,77 +54,5 @@ resource postgresConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configuration
   }
 }
 
-resource sqlDeploymentScriptSetup 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-  name: '${name}-deployment-script-setup'
-  dependsOn: [
-    postgresConfig
-  ]
-  location: location
-  kind: 'AzureCLI'
-  properties: {
-    azCliVersion: '2.37.0'
-    retentionInterval: 'PT1H' // Retain the script resource for 1 hour after it ends running
-    timeout: 'PT5M' // Five minutes
-    cleanupPreference: 'OnSuccess'
-    environmentVariables: [
-      {
-        name: 'SQL_SETUP_SCRIPT'
-        value: loadTextContent('../database/setup.sql')
-      }
-      {
-        name: 'SQL_SCRIPT'
-        value: loadTextContent('../database/aoai-proxy.sql')
-      }
-      {
-        name: 'PG_USER'
-        value: entraAdministratorName
-      }
-      {
-        name: 'PG_DB'
-        value: postgresDatabaseName
-      }
-      {
-        name: 'PG_HOST'
-        value: postgresServer.outputs.POSTGRES_DOMAIN_NAME
-      }
-      {
-        name: 'PGPASSWORD'
-        value: entraAuthorizationToken
-      }
-      {
-        name: 'ADMIN_SYSTEM_ASSIGNED_IDENTITY'
-        value: adminSystemAssignedIdentity
-      }
-      {
-        name: 'PROXY_SYSTEM_ASSIGNED_IDENTITY'
-        value: proxySystemAssignedIdentity
-      }
-    ]
-
-    scriptContent: '''
-      #!/bin/bash
-
-      apk add postgresql-client
-
-      echo "Executing permissions setup script starting"
-      echo "$SQL_SETUP_SCRIPT" > ./setup.sql
-      cat ./setup.sql
-
-      psql -a -U "$PG_USER" -d "postgres" -h "$PG_HOST" -v PG_USER="$PG_USER" -v ADMIN_SYSTEM_ASSIGNED_IDENTITY="$ADMIN_SYSTEM_ASSIGNED_IDENTITY" -v PROXY_SYSTEM_ASSIGNED_IDENTITY="$PROXY_SYSTEM_ASSIGNED_IDENTITY" -w -f ./setup.sql
-      echo "Executing permissions setup script ended"
-
-      echo "Executing database setup script starting"
-      echo "$SQL_SCRIPT" > ./setup.sql
-      cat ./setup.sql
-
-      psql -a -U "$PG_USER" -d "aoai-proxy" -h "$PG_HOST" -w -f ./setup.sql
-      echo "Executing database setup script ended"
-
-      echo "Creating database schema aoai with permissions"
-      psql -a -U "$PG_USER" -d "aoai-proxy" -h "$PG_HOST" -c "REVOKE ALL ON ALL TABLES IN SCHEMA aoai FROM aoai_proxy_app; GRANT DELETE, INSERT, UPDATE, SELECT ON ALL TABLES IN SCHEMA aoai TO aoai_proxy_app; GRANT ALL ON SCHEMA aoai TO azure_pg_admin; GRANT USAGE ON SCHEMA aoai TO azuresu;"
-
-    '''
-  }
-}
-
 output DOMAIN_NAME string = postgresServer.outputs.POSTGRES_DOMAIN_NAME
+output RESOURCE_NAME string = name

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -82,10 +82,8 @@ module admin 'admin.bicep' = {
     containerAppsEnvironmentName: containerApps.outputs.environmentName
     containerRegistryName: containerApps.outputs.registryName
     exists: adminAppExists
-    postgresServer: '${prefix}-postgresql.postgres.database.azure.com'
+    postgresServer: postgresServer.outputs.DOMAIN_NAME
     postgresDatabase: postgresDatabaseName
-    postgresUser: '${prefix}-admin'
-    // postgresPassword: postgresAdminPassword
     postgresEncryptionKey: postgresEncryptionKey
     tenantId: authTenantId
     clientId: authClientId
@@ -106,9 +104,8 @@ module proxy 'proxy.bicep' = {
     containerAppsEnvironmentName: containerApps.outputs.environmentName
     containerRegistryName: containerApps.outputs.registryName
     exists: proxyAppExists
-    postgresServer: '${prefix}-postgresql.postgres.database.azure.com'
+    postgresServer: postgresServer.outputs.DOMAIN_NAME
     postgresDatabase: postgresDatabaseName
-    postgresUser: '${prefix}-proxy'
     postgresEncryptionKey: postgresEncryptionKey
     appInsightsConnectionString: monitoring.outputs.applicationInsightsConnectionString
   }
@@ -122,20 +119,26 @@ module postgresServer 'db.bicep' = {
     name: '${prefix}-postgresql'
     location: location
     tags: tags
-    postgresDatabaseName: postgresDatabaseName
     authType: 'EntraOnly'
     entraAdministratorName: postgresEntraAdministratorName
     entraAdministratorObjectId: postgresEntraAdministratorObjectId
     entraAdministratorType: postgresEntraAdministratorType
-    entraAuthorizationToken: entraAuthorizationToken
-    adminSystemAssignedIdentity: '${prefix}-admin'
-    proxySystemAssignedIdentity: '${prefix}-proxy'
   }
-  // admin and proxy need to exist before the database as their system assigned identities are used to grant access
-  dependsOn: [
-    admin
-    proxy
-  ]
+}
+
+module postgresDbSeeding 'db-seed.bicep' = {
+  name: 'postgres-db-seeding'
+  scope: resourceGroup
+  params: {
+    name: '${prefix}-db-seed'
+    location: location
+    postgresServerName: postgresServer.outputs.RESOURCE_NAME
+    entraAdministratorName: postgresEntraAdministratorName
+    postgresDatabaseName: postgresDatabaseName
+    entraAuthorizationToken: entraAuthorizationToken
+    adminSystemAssignedIdentity: admin.outputs.SERVICE_ADMIN_NAME
+    proxySystemAssignedIdentity: proxy.outputs.SERVICE_PROXY_NAME
+  }
 }
 
 // The Playground frontend
@@ -176,13 +179,19 @@ output AZURE_LOCATION string = location
 output AZURE_CONTAINER_ENVIRONMENT_NAME string = containerApps.outputs.environmentName
 output AZURE_CONTAINER_REGISTRY_NAME string = containerApps.outputs.registryName
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerApps.outputs.registryLoginServer
+
 output SERVICE_PROXY_IDENTITY_PRINCIPAL_ID string = proxy.outputs.SERVICE_PROXY_IDENTITY_PRINCIPAL_ID
 output SERVICE_PROXY_NAME string = proxy.outputs.SERVICE_PROXY_NAME
 output SERVICE_PROXY_URI string = proxy.outputs.SERVICE_PROXY_URI
 output SERVICE_PROXY_IMAGE_NAME string = proxy.outputs.SERVICE_PROXY_IMAGE_NAME
 output SERVICE_PROXY_ENDPOINTS array = ['${proxy.outputs.SERVICE_PROXY_URI}/docs']
+
 output SERVICE_PLAYGROUND_URI string = playground.outputs.SERVICE_WEB_URI
-output SERVICE_ADMIN_IDENTITY_PRINCIPAL_ID string = admin.outputs.principalId
-output SERVICE_ADMIN_NAME string = admin.outputs.name
-output SERVICE_ADMIN_URI string = admin.outputs.uri
-output SERVICE_ADMIN_IMAGE_NAME string = admin.outputs.imageName
+
+output SERVICE_ADMIN_IDENTITY_PRINCIPAL_ID string = admin.outputs.SERVICE_ADMIN_IDENTITY_PRINCIPAL_ID
+output SERVICE_ADMIN_NAME string = admin.outputs.SERVICE_ADMIN_NAME
+output SERVICE_ADMIN_URI string = admin.outputs.SERVICE_ADMIN_URI
+output SERVICE_ADMIN_IMAGE_NAME string = admin.outputs.SERVICE_ADMIN_IMAGE_NAME
+
+output SERVICE_DB_SERVER_NAME string = postgresServer.outputs.RESOURCE_NAME
+output SERVICE_DB_SERVER_FQDN string = postgresServer.outputs.DOMAIN_NAME

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -184,7 +184,6 @@ output SERVICE_PROXY_IDENTITY_PRINCIPAL_ID string = proxy.outputs.SERVICE_PROXY_
 output SERVICE_PROXY_NAME string = proxy.outputs.SERVICE_PROXY_NAME
 output SERVICE_PROXY_URI string = proxy.outputs.SERVICE_PROXY_URI
 output SERVICE_PROXY_IMAGE_NAME string = proxy.outputs.SERVICE_PROXY_IMAGE_NAME
-output SERVICE_PROXY_ENDPOINTS array = ['${proxy.outputs.SERVICE_PROXY_URI}/docs']
 
 output SERVICE_PLAYGROUND_URI string = playground.outputs.SERVICE_WEB_URI
 

--- a/infra/proxy.bicep
+++ b/infra/proxy.bicep
@@ -2,12 +2,12 @@ param name string
 param location string = resourceGroup().location
 param tags object = {}
 
+@description('The name of the user assigned identity that the container app will used to connect to the container registraty')
 param identityName string
 param containerAppsEnvironmentName string
 param containerRegistryName string
 param serviceName string = 'proxy'
 param exists bool
-param postgresUser string
 param postgresDatabase string
 param postgresServer string
 @secure()
@@ -32,7 +32,7 @@ module app 'core/host/container-app-upsert.bicep' = {
     containerRegistryName: containerRegistryName
     targetPort: 3100
     containerCpuCoreCount: '0.75'
-    containerMemory:'1.5Gi'
+    containerMemory: '1.5Gi'
     containerMaxReplicas: 2
     secrets: [
       {
@@ -41,7 +41,7 @@ module app 'core/host/container-app-upsert.bicep' = {
       }
       {
         name: 'postgres-user'
-        value: postgresUser
+        value: name
       }
       {
         name: 'postgres-database'


### PR DESCRIPTION
This pull request addresses issue #269 by refactoring the `db.bicep` file to split the server creation, database creation, and DB schema deployment into separate modules. This separation resolves the issue of using service principals and eliminates the chicken and egg problem.

The changes in this pull request include:

- Splitting the db server creation and db seeding into different scripts

- Simplifying the proxy/admin PG user definition to use the system identity using the name of the resource

- Renaming some outputs for consistency

- Removing the docs uri from the output as it no longer exists

These changes improve the maintainability and flexibility of the codebase.